### PR TITLE
add solutions for ex. 1-4

### DIFF
--- a/Exercises/1-hoisting.js
+++ b/Exercises/1-hoisting.js
@@ -1,5 +1,11 @@
 'use strict';
 
-const fn = null;
+// fixed hoisting
+const fn = () => {
+  let fixedVariable = 0;
+  fixedVariable = 10;
+
+  return fixedVariable;
+};
 
 module.exports = { fn };

--- a/Exercises/2-by-value.js
+++ b/Exercises/2-by-value.js
@@ -1,5 +1,5 @@
 'use strict';
 
-const inc = null;
+const inc = n => n + 1;
 
 module.exports = { inc };

--- a/Exercises/3-by-reference.js
+++ b/Exercises/3-by-reference.js
@@ -1,5 +1,11 @@
 'use strict';
 
-const inc = null;
+const inc = num => {
+  num.n++;
+};
+
+const obj = { n: 5 };
+inc(obj);
+console.dir(obj);
 
 module.exports = { inc };

--- a/Exercises/4-count-types.js
+++ b/Exercises/4-count-types.js
@@ -1,5 +1,16 @@
 'use strict';
 
-const countTypesInArray = null;
+const countTypesInArray = data => {
+  const h = {};
+  for (const i of data) {
+    const type = typeof i;
+    if (h[type]) {
+      h[type]++;
+    } else {
+      h[type] = 1;
+    }
+  }
+  return h;
+};
 
 module.exports = { countTypesInArray };


### PR DESCRIPTION
# Comment

There is a problem with `countTypesInArray` function. The tests require a solution to be 200 signs max, but in this case, we lose the check for `null` values.

As you know `null` in JavaScript has a type of `object`. Thus, the implementation you require, will count objects but not `null`s. So, the function is not suitable for checking all the JS types.

The implementation below considers this JS's quirk:

```
const data = [
  false,
  'a',
  22,
  'hey',
  undefined,
  42,
  12,
  true,
  { a: 12 },
  { name: 'Jack' },
  'foo',
  'bar',
  true,
  null,
  undefined,
  Symbol('a'),
  null
];

const countTypesInArray = data => {
  const h = {};
  for (const item of data) {
    if (typeof item === 'object' && item === null) {
      h['null'] = 1;

      if (h['null'] > 0) {
        h['null']++;
      }
    } else if (typeof item in h) {
      h[typeof item]++;
    } else {
      h[typeof item] = 1;
    }
  }
  return h;
};

console.log(countTypesInArray(data));
```