### PR TITLE
Fix sorting array with mixed BigInt and Number values

### DIFF
--- a/JavaScript/9-bigint.js
+++ b/JavaScript/9-bigint.js
@@ -51,7 +51,13 @@ console.log();
 const array1 = [-2, 7, 1n, 3, -2n, 8n, 5, -4n];
 console.log(array1);
 console.log(array1.sort());
-console.log(array1.sort((a, b) => BigInt(a) - BigInt(b)));
+console.log(array1.sort((a, b) => {
+  const biA = BigInt(a);
+  const biB = BigInt(b);
+  if (biA < biB) return -1;
+  if (biA > biB) return 1;
+  return 0;
+}));
 console.log();
 
 // https://github.com/tc39/proposal-bigint

--- a/JavaScript/9-bigint.js
+++ b/JavaScript/9-bigint.js
@@ -33,8 +33,8 @@ console.log('BigInt(3n / 2n) =', BigInt(3n / 2n));
 // SyntaxError: Cannot convert 1.5 to a BigInt
 
 // console.log('BigInt(1.5) =', BigInt(1.5));
-// RangeError: The number 1.5 is not a safe integer
-// and thus cannot be converted to a BigInt
+// RangeError: The number 1.5 cannot be converted
+// to a BigInt because it is not an integer
 
 console.log('2n > 1n =', 2n > 1n);
 console.log('2n > 1 =', 2n > 1);

--- a/JavaScript/9-bigint.js
+++ b/JavaScript/9-bigint.js
@@ -51,13 +51,7 @@ console.log();
 const array1 = [-2, 7, 1n, 3, -2n, 8n, 5, -4n];
 console.log(array1);
 console.log(array1.sort());
-console.log(array1.sort((a, b) => {
-  const biA = BigInt(a);
-  const biB = BigInt(b);
-  if (biA < biB) return -1;
-  if (biA > biB) return 1;
-  return 0;
-}));
+console.log(array1.sort((a, b) => Number(BigInt(a) - BigInt(b))));
 console.log();
 
 // https://github.com/tc39/proposal-bigint


### PR DESCRIPTION
`TypeError: Cannot convert a BigInt value to a number` error message appears when sorting mixed array (both with BigInt and Number values) with custom sort function (second example):

```
console.log(array1.sort((a, b) => BigInt(a) - BigInt(b)));
                   ^

TypeError: Cannot convert a BigInt value to a number
    at Array.sort (<anonymous>)
```

`sort()` expects to receive a `compareFn` which returns `1`, `-1` or `0`. This expression `BigInt(a) - BigInt(b)` was returning result of BigInt type which led to a TypeError.

I have also actualized an error message in a commented code.