### PR TITLE
Fix ReferenceError in `2-const-let.js`

### DIFF
--- a/JavaScript/2-const-let.js
+++ b/JavaScript/2-const-let.js
@@ -3,7 +3,7 @@
 console.dir({ hoisted }); // { hoisted: undefined }
 hoisted = 5; // Assign 5 to hoisted
 console.dir({ hoisted }); // { hoisted: 5 }
-let hoisted; // Declare hoisted
+var hoisted; // Declare hoisted
 
 let scalarVariable = 6;
 const scalarConstant = 7;

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2021 How.Programming.Works contributors
+Copyright (c) 2017-2023 How.Programming.Works contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
There is a reference error in second example:
```
console.dir({ hoisted }); // { hoisted: undefined }
              ^

ReferenceError: Cannot access 'hoisted' before initialization
```

Using variable without declaring it is not allowed.